### PR TITLE
Better board implementation and use pre-computed file

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,16 +146,47 @@ Each run is composed of 3 phases:
   Update the score of each node that has been visited during this run. If the node is a move by the current player, add the reward.
   If the node is a move by the opponent, then flip the reward: 0 for a win of the current player, number of moves played for a loss.
 
-### Speed bottleneck - `Board.get_possible_moves`
-
-`get_possible_moves` to compute the possible next moves in MonteCarlo
+### Speed bottleneck
 
 A Node contains a board and the next move to play.
 
 How to measure time gains:
 
-- for individual functions: small script using `timeit` (did not keep the script)
+- for individual functions: small script using `timeit`
+
+  ```python
+    def time_get_possible_moves():
+      board.get_possible_moves(args)
+    d = timeit.Timer(time_get_possible_moves)
+    print(min(d.repeat(20, 100000)))
+  ```
+
 - for global algos: `make cli ARG=timer`
+
+#### Board operations: save the board state as a dict of moves vs a list of list
+
+The board operations `Board.play` (with validity and if is win checks) and `Board.get_possible_moves`
+are called a lot of times in the algorithms, so any speed gain on these operations end up making a
+big difference on the final performance.
+
+I tested two different implementations to represent the board state.
+
+Internal representation of the board as a list of list:
+
+```python
+  board = [(Pawns.A, Colors.BLUE), None, None, None],
+            [None, None, None, None],
+            [None, None, None, None],
+            [None, None, None, None],
+```
+
+Internal representation of the board as a dictionnary of the moves:
+
+```python
+  board = {(0,0): ((Pawns.A, Colors.BLUE))}
+```
+
+The Montecarlo search is 2x faster with the move dict implementation.
 
 #### Optimize the move search by removing redundancies
 

--- a/README.md
+++ b/README.md
@@ -186,7 +186,9 @@ Internal representation of the board as a dictionnary of the moves:
   board = {(0,0): ((Pawns.A, Colors.BLUE))}
 ```
 
-The Montecarlo search is 2x faster with the move dict implementation.
+The Montecarlo search is 1.3-1.5x faster with the move dict implementation.
+Time for the bot to compute the second move (5000 iterations) deployed with Flask: from
+23s to 15s.
 
 #### Optimize the move search by removing redundancies
 
@@ -223,6 +225,9 @@ On the top of my head, to reduce the file size:
 
 - require less space to save a node (do not save all values or find a more compact way of writing them), e.g. Ar for an A red pawn.
 - save the "levels" (one level = a number of pawns on the board + whether it is player 1 or 2's turn) in different files
+
+Second try: save the data in a more compressed way, computed with 50'000 iterations, produces a 680Mb file
+naive implementation with file loaded at each request
 
 #### Node class: save children
 

--- a/README.md
+++ b/README.md
@@ -236,11 +236,17 @@ On the top of my head, to reduce the file size:
 - require less space to save a node (do not save all values or find a more compact way of writing them), e.g. Ar for an A red pawn.
 - save the "levels" (one level = a number of pawns on the board + whether it is player 1 or 2's turn) in different files
 
-Second try: save the data in a more compressed way, computed with 50'000 iterations, save only up to depth 4 included, produces a 355Mb file
-naive implementation:
+Second try:
 
-- pre-compute the whole game tree without taking advantage of board symmetries
-- with file loaded at each request
+- save the data in a more compressed way
+  - save only the data up to depth = 3
+  - save only the bot player moves (i.e. red player, and assume that blue starts)
+- 50'000 iterations of the MonteCarlo algorithm (100'000 iterations leads to a process kill)
+- consider all possible move (did not remove redundancies) - removing redundancies would necessitate extra code at play time to infer best moves from symetries
+- save only up to depth 3 included (for a sequence of play Blue(depth=0), Red(depth=1), Blue(depth=2), Red(depth=3)), produces a 81Mb file
+- at move 3, most nodes have not been visited
+
+So to get improvements with the pre-compute method, we need to exploit symetries and do more iterations.
 
 #### Node class: save children
 

--- a/README.md
+++ b/README.md
@@ -132,7 +132,7 @@ Each run is composed of 3 phases:
 
 1. Selection
 
-  Select the next move: if a move has not been tried yet, choose it. Else, use the UCP formula to compute
+  Select the next move: if a move has not been tried yet, choose it. Else, use the UCB formula to compute
   each move UCT value and choose the one with the max UCT value.
 
 2. Evaluate the node
@@ -226,8 +226,11 @@ On the top of my head, to reduce the file size:
 - require less space to save a node (do not save all values or find a more compact way of writing them), e.g. Ar for an A red pawn.
 - save the "levels" (one level = a number of pawns on the board + whether it is player 1 or 2's turn) in different files
 
-Second try: save the data in a more compressed way, computed with 50'000 iterations, produces a 680Mb file
-naive implementation with file loaded at each request
+Second try: save the data in a more compressed way, computed with 50'000 iterations, save only up to depth 4 included, produces a 355Mb file
+naive implementation:
+
+- pre-compute the whole game tree without taking advantage of board symmetries
+- with file loaded at each request
 
 #### Node class: save children
 

--- a/README.md
+++ b/README.md
@@ -44,8 +44,18 @@ Tested on Linux with Python 3.12
 To use the web interface, do:
 
 ```bash
-        make dev
+        make devg
 ```
+
+To get a better bot (from the web interface), do:
+
+```bash
+        make cli ARG=montecarlo
+        make devg
+```
+
+`make cli ARG=montecarlo` pre-computes the game tree, going much deeper than the on-the-fly algorithm. The result is then used for the first
+few moves on the board, subsequent moves are calcultaed on the fly.
 
 ## Timing
 

--- a/README.md
+++ b/README.md
@@ -148,8 +148,7 @@ Each run is composed of 3 phases:
 
 ### Speed bottleneck - `Board.get_possible_moves`
 
-`get_possible_moves` to compute the possible next moves in MonteCarlo, it takes about 1min for
-the not optimised version on the game board.
+`get_possible_moves` to compute the possible next moves in MonteCarlo
 
 A Node contains a board and the next move to play.
 

--- a/src/quantikai/bot/comparison.py
+++ b/src/quantikai/bot/comparison.py
@@ -60,7 +60,7 @@ def init_test_values():
         Move(3, 3, Pawns.A, Colors.RED),
     ]
     for move in moves:
-        tmp_board = copy.deepcopy(board)
+        tmp_board: Board = copy.deepcopy(board)
         tmp_player = copy.deepcopy(current_player)
 
         tmp_board.play(move)

--- a/src/quantikai/bot/main.py
+++ b/src/quantikai/bot/main.py
@@ -1,12 +1,20 @@
+import pathlib
+
 from quantikai.game import Board, Player, Move
 from quantikai.bot import montecarlo
 
 
-def get_best_move(board: Board, current_player: Player, other_player: Player) -> Move:
+def get_best_move(
+    board: Board,
+    current_player: Player,
+    other_player: Player,
+    game_tree_file: pathlib.Path | None,
+) -> Move:
 
     best_move = montecarlo.get_best_move(
         board=board,
         current_player=current_player,
         other_player=other_player,
+        game_tree_file=game_tree_file,
     )
     return best_move

--- a/src/quantikai/bot/montecarlo/game_tree.py
+++ b/src/quantikai/bot/montecarlo/game_tree.py
@@ -1,7 +1,7 @@
 import pathlib
 import json
 
-from quantikai.game import Board, FrozenBoard, Move
+from quantikai.game import Board, FrozenBoard, Move, Colors
 from quantikai.bot.montecarlo.node import Node
 from quantikai.bot.montecarlo.score import MonteCarloScore
 
@@ -45,7 +45,7 @@ class GameTree:
         n_visited = None
         best_score = None
         for node, montecarlo in self._game_tree.items():
-            if node.board == frozen_board.board and node.move_to_play is not None:
+            if node.board == frozen_board and node.move_to_play is not None:
                 if montecarlo.times_visited > 0:
                     if (
                         n_visited is None
@@ -98,7 +98,7 @@ class GameTree:
 
     # TODO
     # Test, and remove these functions if I do not implement a pre-compute of the game tree
-    def to_file(self, path: pathlib.Path, max_depth: int):
+    def to_file(self, path: pathlib.Path, player_color: Colors, max_depth: int = 16):
         game_tree_json = (
             {
                 "node": node.to_compressed(),
@@ -106,6 +106,8 @@ class GameTree:
             }
             for node, montecarlo in self._game_tree.items()
             if len(node.board) <= max_depth
+            and node.move_to_play is not None
+            and node.move_to_play.color == player_color
         )
 
         class StreamArray(list):

--- a/src/quantikai/bot/montecarlo/game_tree.py
+++ b/src/quantikai/bot/montecarlo/game_tree.py
@@ -102,8 +102,8 @@ class GameTree:
     def to_file(self, path: pathlib.Path):
         game_tree_json = (
             {
-                "node": node.to_json(),
-                "montecarlo": asdict(montecarlo),
+                "node": node.to_compressed(),
+                "montecarlo": montecarlo.to_compressed(),
             }
             for node, montecarlo in self._game_tree.items()
         )
@@ -126,18 +126,8 @@ class GameTree:
         def object_hook(self, dct):
             if "node" in dct:
                 return (
-                    Node(
-                        board=tuple(
-                            tuple(None if item is None else tuple(item) for item in row)
-                            for row in dct["node"]["board"]
-                        ),
-                        move_to_play=(
-                            None
-                            if dct["node"]["move_to_play"] is None
-                            else Move(**dct["node"]["move_to_play"])
-                        ),
-                    ),
-                    MonteCarloScore(**dct["montecarlo"]),
+                    Node.from_compressed(dct["node"]),
+                    MonteCarloScore.from_compressed(dct["montecarlo"]),
                 )
             return dct
 

--- a/src/quantikai/bot/montecarlo/game_tree.py
+++ b/src/quantikai/bot/montecarlo/game_tree.py
@@ -1,6 +1,5 @@
 import pathlib
 import json
-from dataclasses import asdict
 
 from quantikai.game import Board, FrozenBoard, Move
 from quantikai.bot.montecarlo.node import Node
@@ -46,7 +45,7 @@ class GameTree:
         n_visited = None
         best_score = None
         for node, montecarlo in self._game_tree.items():
-            if node.board == frozen_board and node.move_to_play is not None:
+            if node.board == frozen_board.board and node.move_to_play is not None:
                 if montecarlo.times_visited > 0:
                     if (
                         n_visited is None
@@ -99,13 +98,14 @@ class GameTree:
 
     # TODO
     # Test, and remove these functions if I do not implement a pre-compute of the game tree
-    def to_file(self, path: pathlib.Path):
+    def to_file(self, path: pathlib.Path, max_depth: int):
         game_tree_json = (
             {
                 "node": node.to_compressed(),
                 "montecarlo": montecarlo.to_compressed(),
             }
             for node, montecarlo in self._game_tree.items()
+            if len(node.board) <= max_depth
         )
 
         class StreamArray(list):

--- a/src/quantikai/bot/montecarlo/game_tree.py
+++ b/src/quantikai/bot/montecarlo/game_tree.py
@@ -69,7 +69,7 @@ class GameTree:
             return list()
         best_node = Node(board=frozen_board, move_to_play=best_move)
         best_play = [(best_node, self._game_tree[best_node])]
-        tmp_board = Board(board=frozen_board.board)
+        tmp_board = Board(board=frozen_board)
 
         for _ in range(depth):
             tmp_board.play(best_node.move_to_play)

--- a/src/quantikai/bot/montecarlo/main.py
+++ b/src/quantikai/bot/montecarlo/main.py
@@ -8,7 +8,7 @@ from quantikai.bot.montecarlo.game_tree import GameTree
 
 ITERATIONS = 5000
 USE_DEPTH = True
-GAME_TREE_FILE_MAX_DEPTH = 4
+GAME_TREE_FILE_MAX_DEPTH = 2
 
 
 def _explore_node(
@@ -271,4 +271,4 @@ def generate_tree(
         use_depth=use_depth,
         all_possible_moves=True,  # compute the whole tree, no optimization on "get_possible_moves"
     )
-    game_tree.to_file(path=path, max_depth=max_depth)
+    game_tree.to_file(path=path, player_color=current_player.color, max_depth=max_depth)

--- a/src/quantikai/bot/montecarlo/main.py
+++ b/src/quantikai/bot/montecarlo/main.py
@@ -1,14 +1,14 @@
 import copy
 import pathlib
 
-from quantikai.game import Board, Player, Move
+from quantikai.game import Board, Player, Move, Colors
 from quantikai.bot.montecarlo.node import Node
 from quantikai.bot.montecarlo.score import MonteCarloScore
 from quantikai.bot.montecarlo.game_tree import GameTree
 
 ITERATIONS = 5000
 USE_DEPTH = True
-GAME_TREE_FILE_MAX_DEPTH = 2
+GAME_TREE_FILE_MAX_DEPTH = 3
 
 
 def _explore_node(
@@ -256,19 +256,33 @@ def get_best_play(
 def generate_tree(
     path: pathlib.Path,
     board: Board,
-    current_player: Player,
-    other_player: Player,
+    first_player: Player,
+    second_player: Player,
+    main_player_color: Colors,
     max_depth: int = GAME_TREE_FILE_MAX_DEPTH,
     iterations: int = ITERATIONS,
     use_depth: bool = USE_DEPTH,
-):
+) -> None:
+    """Generate the MonteCarlo algorithm game tree and
+    save it to a file.
+
+    Args:
+        path (pathlib.Path): path where to save the generated file
+        board (Board): starting board
+        first_player (Player): player that plays first on this board
+        second_player (Player): player that plays second on this board
+        main_player_color (Colors): keep only the moves for that player
+        max_depth (int, optional): max depth of the game tree that is saved. Defaults to GAME_TREE_FILE_MAX_DEPTH.
+        iterations (int, optional): MonteCarlo algorithm parameter: number of iterations. Defaults to ITERATIONS.
+        use_depth (bool, optional): MonteCarlo algorithm parameter: reward depends on the depth. Defaults to USE_DEPTH.
+    """
 
     game_tree = _montecarlo_algo(
         board=board,
-        current_player=current_player,
-        other_player=other_player,
+        current_player=first_player,
+        other_player=second_player,
         iterations=iterations,
         use_depth=use_depth,
         all_possible_moves=True,  # compute the whole tree, no optimization on "get_possible_moves"
     )
-    game_tree.to_file(path=path, player_color=current_player.color, max_depth=max_depth)
+    game_tree.to_file(path=path, player_color=main_player_color, max_depth=max_depth)

--- a/src/quantikai/bot/montecarlo/main.py
+++ b/src/quantikai/bot/montecarlo/main.py
@@ -8,6 +8,7 @@ from quantikai.bot.montecarlo.game_tree import GameTree
 
 ITERATIONS = 5000
 USE_DEPTH = True
+GAME_TREE_FILE_MAX_DEPTH = 4
 
 
 def _explore_node(
@@ -15,6 +16,7 @@ def _explore_node(
     parent_node: Node,
     board: Board,
     player: Player,
+    all_possible_moves: bool,
 ) -> tuple[bool, Node | None]:
     """Explore one node: compute children nodes and execute one.
 
@@ -30,7 +32,7 @@ def _explore_node(
     possible_moves = board.get_possible_moves(
         player.pawns,
         player.color,
-        optimize=True,
+        optimize=not all_possible_moves,
     )
 
     # end case: the parent node is a leaf node
@@ -64,10 +66,19 @@ def _montecarlo_algo(
     other_player: Player,
     iterations: int,
     use_depth: bool,
+    all_possible_moves: bool = False,
 ) -> GameTree:
-    """Execute the montecarlo algorithm, up to generating
-    the 'game tree' i.e. the graph of the moves with their
-    scores.
+    """Execute the montecarlo algorithm, up to generating the 'game tree' i.e. the graph of the moves with their scores.
+    Args:
+        board (Board): _description_
+        current_player (Player): _description_
+        other_player (Player): _description_
+        iterations (int): _description_
+        use_depth (bool): _description_
+        all_possible_moves (bool, optional): whether to consider redundant moves or not (eg by exploiting board symmetry). Defaults to False.
+
+    Returns:
+        GameTree: _description_
     """
     frozen_board = board.get_frozen()  # hashable version of the board
     root_node = Node(board=frozen_board)
@@ -98,6 +109,7 @@ def _montecarlo_algo(
                 parent_node=parent_node,
                 board=tmp_board,
                 player=player,
+                all_possible_moves=all_possible_moves,
             )
             if node_to_explore is not None:
                 iteration_nodes.append(node_to_explore)
@@ -174,7 +186,7 @@ def get_best_move(
     """
     frozen_board = board.get_frozen()  # hashable version of the board
     game_tree = None
-    if game_tree_file is not None:
+    if game_tree_file is not None and len(frozen_board) <= GAME_TREE_FILE_MAX_DEPTH:
         game_tree = GameTree.from_file(path=game_tree_file)
     else:
         game_tree = _montecarlo_algo(
@@ -199,7 +211,7 @@ def get_move_stats(
 ) -> list[tuple[Move, MonteCarloScore]]:
     frozen_board = board.get_frozen()  # hashable version of the board
     game_tree = None
-    if game_tree_file is not None:
+    if game_tree_file is not None and len(frozen_board) <= GAME_TREE_FILE_MAX_DEPTH:
         game_tree = GameTree.from_file(game_tree_file)
     else:
         game_tree = _montecarlo_algo(
@@ -224,7 +236,7 @@ def get_best_play(
 
     frozen_board = board.get_frozen()  # hashable version of the board
     game_tree = None
-    if game_tree_file is not None:
+    if game_tree_file is not None and len(frozen_board) <= GAME_TREE_FILE_MAX_DEPTH:
         game_tree = GameTree.from_file(game_tree_file)
     else:
         game_tree = _montecarlo_algo(
@@ -246,6 +258,7 @@ def generate_tree(
     board: Board,
     current_player: Player,
     other_player: Player,
+    max_depth: int = GAME_TREE_FILE_MAX_DEPTH,
     iterations: int = ITERATIONS,
     use_depth: bool = USE_DEPTH,
 ):
@@ -256,5 +269,6 @@ def generate_tree(
         other_player=other_player,
         iterations=iterations,
         use_depth=use_depth,
+        all_possible_moves=True,  # compute the whole tree, no optimization on "get_possible_moves"
     )
-    game_tree.to_file(path=path)
+    game_tree.to_file(path=path, max_depth=max_depth)

--- a/src/quantikai/bot/montecarlo/node.py
+++ b/src/quantikai/bot/montecarlo/node.py
@@ -17,6 +17,17 @@ class Node:
         return {
             "board": self.board.to_json(),
             "move_to_play": (
-                None if self.move_to_play is None else asdict(self.move_to_play)
+                None if self.move_to_play is None else self.move_to_play.to_json()
             ),
         }
+    def to_compressed(self):
+        return [
+            self.board.to_compressed(),
+            None if self.move_to_play is None else self.move_to_play.to_compressed()
+        ]
+    @classmethod
+    def from_compressed(cls, body):
+        return cls(
+            board=FrozenBoard.from_compressed(body[0]),
+            move_to_play=Move.from_compressed(body[1])
+        )

--- a/src/quantikai/bot/montecarlo/node.py
+++ b/src/quantikai/bot/montecarlo/node.py
@@ -20,14 +20,16 @@ class Node:
                 None if self.move_to_play is None else self.move_to_play.to_json()
             ),
         }
+
     def to_compressed(self):
         return [
             self.board.to_compressed(),
-            None if self.move_to_play is None else self.move_to_play.to_compressed()
+            None if self.move_to_play is None else self.move_to_play.to_compressed(),
         ]
+
     @classmethod
     def from_compressed(cls, body):
         return cls(
             board=FrozenBoard.from_compressed(body[0]),
-            move_to_play=Move.from_compressed(body[1])
+            move_to_play=Move.from_compressed(body[1]),
         )

--- a/src/quantikai/bot/montecarlo/node.py
+++ b/src/quantikai/bot/montecarlo/node.py
@@ -15,7 +15,7 @@ class Node:
 
     def to_json(self):
         return {
-            "board": self.board.board,
+            "board": self.board.to_json(),
             "move_to_play": (
                 None if self.move_to_play is None else asdict(self.move_to_play)
             ),

--- a/src/quantikai/bot/montecarlo/score.py
+++ b/src/quantikai/bot/montecarlo/score.py
@@ -33,3 +33,9 @@ class MonteCarloScore:
             2 * math.log(times_parent_visited) / self.times_visited
         )
         return self.uct
+
+    def to_compressed(self):
+        return [self.times_visited,self.score]
+    @classmethod
+    def from_compressed(cls, body):
+        return cls(times_visited=body[0], score=body[1])

--- a/src/quantikai/bot/montecarlo/score.py
+++ b/src/quantikai/bot/montecarlo/score.py
@@ -35,7 +35,8 @@ class MonteCarloScore:
         return self.uct
 
     def to_compressed(self):
-        return [self.times_visited,self.score]
+        return [self.times_visited, self.score]
+
     @classmethod
     def from_compressed(cls, body):
         return cls(times_visited=body[0], score=body[1])

--- a/src/quantikai/cli.py
+++ b/src/quantikai/cli.py
@@ -79,9 +79,10 @@ def generate_montecarlo_tree():
     bot.montecarlo.generate_tree(
         path=pathlib.Path("montecarlo_tree_blue.json"),
         board=game.Board(),
-        current_player=game.Player(color=game.Colors.BLUE),
-        other_player=game.Player(color=game.Colors.RED),
-        iterations=500000,
+        first_player=game.Player(color=game.Colors.BLUE),
+        second_player=game.Player(color=game.Colors.RED),
+        main_player_color=game.Colors.RED,
+        iterations=50000, # 50000 OK, 100000 = process killed
         use_depth=True,
     )
     # Generate tree for the other player color

--- a/src/quantikai/cli.py
+++ b/src/quantikai/cli.py
@@ -74,8 +74,8 @@ def timer():
     bot.get_method_times()
 
 
-@app.command()
-def montecarlo():
+@app.command("montecarlo")
+def generate_montecarlo_tree():
     bot.montecarlo.generate_tree(
         path=pathlib.Path("montecarlo_tree.json"),
         board=game.Board(),

--- a/src/quantikai/cli.py
+++ b/src/quantikai/cli.py
@@ -77,10 +77,18 @@ def timer():
 @app.command("montecarlo")
 def generate_montecarlo_tree():
     bot.montecarlo.generate_tree(
-        path=pathlib.Path("montecarlo_tree.json"),
+        path=pathlib.Path("montecarlo_tree_blue.json"),
         board=game.Board(),
         current_player=game.Player(color=game.Colors.BLUE),
         other_player=game.Player(color=game.Colors.RED),
+        iterations=50000,
+        use_depth=True,
+    )
+    bot.montecarlo.generate_tree(
+        path=pathlib.Path("montecarlo_tree_red.json"),
+        board=game.Board(),
+        current_player=game.Player(color=game.Colors.RED),
+        other_player=game.Player(color=game.Colors.BLUE),
         iterations=50000,
         use_depth=True,
     )

--- a/src/quantikai/cli.py
+++ b/src/quantikai/cli.py
@@ -81,17 +81,18 @@ def generate_montecarlo_tree():
         board=game.Board(),
         current_player=game.Player(color=game.Colors.BLUE),
         other_player=game.Player(color=game.Colors.RED),
-        iterations=50000,
+        iterations=500000,
         use_depth=True,
     )
-    bot.montecarlo.generate_tree(
-        path=pathlib.Path("montecarlo_tree_red.json"),
-        board=game.Board(),
-        current_player=game.Player(color=game.Colors.RED),
-        other_player=game.Player(color=game.Colors.BLUE),
-        iterations=50000,
-        use_depth=True,
-    )
+    # Generate tree for the other player color
+    # bot.montecarlo.generate_tree(
+    #     path=pathlib.Path("montecarlo_tree_red.json"),
+    #     board=game.Board(),
+    #     current_player=game.Player(color=game.Colors.RED),
+    #     other_player=game.Player(color=game.Colors.BLUE),
+    #     iterations=50000,
+    #     use_depth=True,
+    # )
 
 
 if __name__ == "__main__":

--- a/src/quantikai/game/board.py
+++ b/src/quantikai/game/board.py
@@ -9,19 +9,21 @@ from quantikai.game.move import Move
 
 @dataclass(frozen=True, eq=True)
 class FrozenBoard:
-    board: tuple[tuple[tuple[Pawns, Colors] | None]]
+    board: tuple[tuple[tuple[int, int], tuple[Pawns, Colors]]]
 
 
 class Board:
-    board: list[list[tuple[Pawns, Colors] | None]]
+    board: dict[tuple[int, int], tuple[Pawns, Colors]]
+    size: int
 
     def __init__(self, board=None):
         if board is not None:
-            assert len(board) == 4 and len(board[0]) == 4
-            self.board = [[elt for elt in row] for row in board]
+            self.board = board
         else:
-            self.board = [[None for _ in range(4)] for _ in range(4)]
+            self.board = dict()
+        self.size = 4
 
+    # TODO
     @classmethod
     def from_json(cls, body: list[list[tuple[str, str] | None]]):
         # TODO check values in body
@@ -35,6 +37,7 @@ class Board:
             ]
         )
 
+    # TODO
     def to_json(self):
         return [
             [None if v is None else (v[0].name, v[1].name) for v in row]
@@ -43,9 +46,10 @@ class Board:
 
     def play(self, move: Move):
         self._check_move_is_valid(move)
-        self.board[move.x][move.y] = (move.pawn, move.color)
+        self.board[(move.x, move.y)] = (move.pawn, move.color)
         return self._move_is_a_win(move.x, move.y)
 
+    # TODO
     def print(self):
         upper_idx = "  "
         for x in range(0, 4):
@@ -56,9 +60,10 @@ class Board:
         for i in range(4):
             str_board += str(i) + " "
             for j in range(4):
-                if self.board[i][j]:
+                if (i, j) in self.board:
                     str_board += self._ctxt(
-                        "|__" + self.board[i][j][0].value + "_|", self.board[i][j][1]
+                        "|__" + self.board[(i, j)][0].value + "_|",
+                        self.board[(i, j)][1],
                     )
                 else:
                     str_board += "|____|"
@@ -71,8 +76,8 @@ class Board:
         print(str_board)
 
     def have_possible_move(self, color: Colors):
-        for x, row in enumerate(self.board):
-            for y, _ in enumerate(row):
+        for x in range(self.size):
+            for y in range(self.size):
                 for pawn in Pawns:
                     try:
                         self._check_move_is_valid(Move(x, y, pawn, color))
@@ -94,17 +99,9 @@ class Board:
         Returns:
             set[Move]: _description_
         """
-        board_len = len(self.board)
         if optimize:
-            pawns_on_board: set[Move] = set()
-            for x in range(board_len):
-                for y in range(board_len):
-                    if self.board[x][y] is not None:
-                        pawns_on_board.add(
-                            Move(x, y, self.board[x][y][0], self.board[x][y][1])
-                        )
             # Case 1: No pawn on the board
-            if len(pawns_on_board) == 0:
+            if len(self.board) == 0:
                 # Only need to check for one pawn and one section minus one cell because of symmetry
                 # Actually I am not even sure the first move matters
                 return {
@@ -116,105 +113,90 @@ class Board:
             # Diagonal symmetry: both sections next to the played section are the same and in opposite section 2 cells are
             # the same
             # Pawn: either play the same pawn or a different one. If different, does not matter which one
-            if len(pawns_on_board) == 1:
-                # x, y, pawn, _ = pawns_on_board.pop()
-                cell_pawn = pawns_on_board.pop()
-                other_pawn = [p for p in Pawns if p != cell_pawn.pawn][0]
+            if len(self.board) == 1:
+                (bx, by), (bpawn, _) = list(self.board.items())[0]
+                other_pawn = [p for p in Pawns if p != bpawn][0]
                 return (
                     {
                         # other pawn, same section
                         Move(i, j, other_pawn, color)
-                        for (i, j) in self._get_section_elements(
-                            cell_pawn.x, cell_pawn.y
-                        )
-                        if (i, j) != (cell_pawn.x, cell_pawn.y)
+                        for (i, j) in self._get_section_elements(bx, by)
+                        if (i, j) != (bx, by)
                     }
                     | {
                         # other pawn, adjacent section
                         Move(i, j, other_pawn, color)
-                        for (i, j) in self._get_section_elements(
-                            (cell_pawn.x + 2) % 4, cell_pawn.y
-                        )
+                        for (i, j) in self._get_section_elements((bx + 2) % 4, by)
                     }
                     | {
                         # same pawn, adjacent section (only 2 possible positions)
-                        Move(i, j, cell_pawn.pawn, color)
-                        for (i, j) in self._get_section_elements(
-                            (cell_pawn.x + 2) % 4, cell_pawn.y
-                        )
-                        if i != cell_pawn.x and j != cell_pawn.y
+                        Move(i, j, bpawn, color)
+                        for (i, j) in self._get_section_elements((bx + 2) % 4, by)
+                        if i != bx and j != by
                     }
                     | {
                         # same or other pawn, opposite section
                         Move(i, j, p, color)
-                        for p in [cell_pawn.pawn, other_pawn]
+                        for p in [bpawn, other_pawn]
                         for i, j in self._get_section_elements(
-                            (cell_pawn.x + 2) % 4, (cell_pawn.y + 2) % 4
+                            (bx + 2) % 4, (by + 2) % 4
                         )
                     }
                 )
         # Get all possible moves
         moves: set = {
-            (x, y, pawn, color)
-            for x in range(board_len)
-            for y in range(board_len)
-            for pawn in pawns
+            (i, j, p, color)
+            for i in range(self.size)
+            for j in range(self.size)
+            for p in pawns
         }
-        for x in range(board_len):
-            for y in range(board_len):
-                if self.board[x][y] is not None:
-                    for pawn in pawns:
-                        moves.discard((x, y, pawn, color))
-                    if self.board[x][y][1] != color:
-                        opponent_pawn: Pawns = self.board[x][y][0]
-                        for idx in range(board_len):
-                            moves.discard((idx, y, opponent_pawn, color))
-                            moves.discard((x, idx, opponent_pawn, color))
-                        for i, j in self._get_section_elements(x, y):
-                            moves.discard((i, j, opponent_pawn, color))
+        for (bx, by), (bpawn, bcolor) in self.board.items():
+            for pawn in pawns:
+                moves.discard((bx, by, pawn, color))
+            if bcolor != color:
+                for idx in range(self.size):
+                    moves.discard((idx, by, bpawn, color))
+                    moves.discard((bx, idx, bpawn, color))
+                for i, j in self._get_section_elements(bx, by):
+                    moves.discard((i, j, bpawn, color))
         # Optimization: from 90s to 59s by using tuples instead of Move in the previous steps
         return {Move(*item) for item in moves}
 
     def get_frozen(self) -> FrozenBoard:
-        board_len = len(self.board)
         return FrozenBoard(
-            tuple(
-                tuple(self.board[x][y] for y in range(board_len))
-                for x in range(board_len)
-            )
+            board=tuple((key, value) for key, value in self.board.items())
         )
 
     def _check_move_is_valid(self, move: Move):
-        if (
-            move.x < 0
-            or move.y < 0
-            or move.x >= len(self.board)
-            or move.y >= len(self.board[0])
-        ):
+        if move.x < 0 or move.y < 0 or move.x >= self.size or move.y >= self.size:
             raise InvalidMoveError(
                 "x and y must be between 0 and 4, their values are: "
                 + str(move.x)
                 + " "
                 + str(move.y)
             )
-        if self.board[move.x][move.y]:
+        if (move.x, move.y) in self.board:
             raise InvalidMoveError("already a pawn there")
-        for element in self.board[move.x]:
-            if element and element[0] == move.pawn and element[1] != move.color:
-                raise InvalidMoveError("there is an opponent's pawn in that row")
-        for row in self.board:
+        for j in range(self.size):
             if (
-                row[move.y]
-                and row[move.y][0] == move.pawn
-                and row[move.y][1] != move.color
+                (move.x, j) in self.board
+                and self.board[(move.x, j)][0] == move.pawn
+                and self.board[(move.x, j)][1] != move.color
+            ):
+                raise InvalidMoveError("there is an opponent's pawn in that row")
+        for i in range(self.size):
+            if (
+                (i, move.y) in self.board
+                and self.board[(i, move.y)][0] == move.pawn
+                and self.board[(i, move.y)][1] != move.color
             ):
                 raise InvalidMoveError("there is an opponent's pawn in that column")
         # check section
         for i, j in self._get_section_elements(move.x, move.y):
             if (
-                self.board[i][j] is not None
-                and self.board[i][j][0] == move.pawn
-                and self.board[i][j][1] != move.color
+                (i, j) in self.board
+                and self.board[(i, j)][0] == move.pawn
+                and self.board[(i, j)][1] != move.color
             ):
                 raise InvalidMoveError("there is an opponent's pawn in that section")
 
@@ -228,27 +210,27 @@ class Board:
             return "\033[41m" + txt + "\033[0m"
 
     def _row_win(self, x: int):
-        others: set[Pawns] = set()
-        for element in self.board[x]:
-            if not element or element[0] in others:
+        other_pawns: set[Pawns] = set()
+        for j in range(self.size):
+            if not (x, j) in self.board or self.board[(x, j)][0] in other_pawns:
                 return False
-            others.add(element[0])
+            other_pawns.add(self.board[(x, j)][0])
         return True
 
     def _column_win(self, y: int):
-        others: set[Pawns] = set()
-        for row in self.board:
-            if row[y] is None or row[y][0] in others:
+        other_pawns: set[Pawns] = set()
+        for i in range(self.size):
+            if not (i, y) in self.board or self.board[(i, y)][0] in other_pawns:
                 return False
-            others.add(row[y][0])
+            other_pawns.add(self.board[(i, y)][0])
         return True
 
     def _section_win(self, x: int, y: int):
         others: set[Pawns] = set()
         for i, j in self._get_section_elements(x, y):
-            if self.board[i][j] is None or self.board[i][j][0] in others:
+            if not (i, j) in self.board or self.board[(i, j)][0] in others:
                 return False
-            others.add(self.board[i][j][0])
+            others.add(self.board[(i, j)][0])
         return True
 
     def _get_section_elements(

--- a/src/quantikai/game/board.py
+++ b/src/quantikai/game/board.py
@@ -23,9 +23,7 @@ class FrozenBoard:
 
     @classmethod
     def from_compressed(cls, body):
-        return cls(frozenset({
-            tuple(item) for item in body
-        }))
+        return cls(frozenset({tuple(item) for item in body}))
 
 
 class Board:

--- a/src/quantikai/game/board.py
+++ b/src/quantikai/game/board.py
@@ -16,7 +16,16 @@ class FrozenBoard:
             yield item
 
     def to_json(self):
-        return json.dumps(list(self._board))
+        return list(self._board)
+
+    def to_compressed(self):
+        return list(self._board)
+
+    @classmethod
+    def from_compressed(cls, body):
+        return cls(frozenset({
+            tuple(item) for item in body
+        }))
 
 
 class Board:

--- a/src/quantikai/game/board.py
+++ b/src/quantikai/game/board.py
@@ -9,21 +9,31 @@ from quantikai.game.move import Move
 
 @dataclass(frozen=True, eq=True)
 class FrozenBoard:
-    _board: frozenset[tuple[int, int, Pawns, Colors]]
+    board: frozenset[tuple[int, int, Pawns, Colors]]
+
+    def __len__(self):
+        return len(self.board)
 
     def items(self):
-        for item in self._board:
+        for item in self.board:
             yield item
 
     def to_json(self):
-        return list(self._board)
+        return list(self.board)
 
     def to_compressed(self):
-        return list(self._board)
+        return list(self.board)
 
     @classmethod
     def from_compressed(cls, body):
-        return cls(frozenset({tuple(item) for item in body}))
+        return cls(
+            frozenset(
+                {
+                    (int(item[0]), int(item[1]), Pawns[item[2]], Colors[item[3]])
+                    for item in body
+                }
+            )
+        )
 
 
 class Board:

--- a/src/quantikai/game/move.py
+++ b/src/quantikai/game/move.py
@@ -10,6 +10,7 @@ class Move:
     pawn: Pawns
     color: Colors
 
+    # TODO
     def to_json(self):
         return {
             "x": self.x,

--- a/src/quantikai/game/move.py
+++ b/src/quantikai/game/move.py
@@ -18,3 +18,8 @@ class Move:
             "pawn": self.pawn.name,
             "color": self.color.name,
         }
+    def to_compressed(self):
+        return [self.x, self.y, self.pawn.name, self.color.name]
+    @classmethod
+    def from_compressed(cls, body):
+        return cls(x=body[0],y=body[1],pawn=Pawns[body[2]],color=Colors[body[3]])

--- a/src/quantikai/game/move.py
+++ b/src/quantikai/game/move.py
@@ -24,4 +24,6 @@ class Move:
 
     @classmethod
     def from_compressed(cls, body):
+        if body is None:
+            return None
         return cls(x=body[0], y=body[1], pawn=Pawns[body[2]], color=Colors[body[3]])

--- a/src/quantikai/game/move.py
+++ b/src/quantikai/game/move.py
@@ -18,8 +18,10 @@ class Move:
             "pawn": self.pawn.name,
             "color": self.color.name,
         }
+
     def to_compressed(self):
         return [self.x, self.y, self.pawn.name, self.color.name]
+
     @classmethod
     def from_compressed(cls, body):
-        return cls(x=body[0],y=body[1],pawn=Pawns[body[2]],color=Colors[body[3]])
+        return cls(x=body[0], y=body[1], pawn=Pawns[body[2]], color=Colors[body[3]])

--- a/src/quantikai/game/player.py
+++ b/src/quantikai/game/player.py
@@ -23,9 +23,11 @@ class Player:
             t += pawn.value + " "
         return "Player " + self.color.name + " available pawns: " + t
 
+    # TODO
     @classmethod
     def from_json(cls, body):
         return cls(color=Colors[body["color"]], pawns=[Pawns(p) for p in body["pawns"]])
 
+    # TODO
     def to_json(self):
         return {"color": self.color.name, "pawns": [p.name for p in self.pawns]}

--- a/src/quantikai/wsgi.py
+++ b/src/quantikai/wsgi.py
@@ -106,8 +106,10 @@ def create_app():
         board = game.Board.from_json(session["board"])
         human_player = game.Player.from_json(session["human_player"])
         bot_player = game.Player.from_json(session["bot_player"])
+        best_play = None
         if session["next_player"] == "human_player":
-            return montecarlo.get_best_play(board, human_player, bot_player)
-        return montecarlo.get_best_play(board, bot_player, human_player)
+            best_play = montecarlo.get_best_play(board, human_player, bot_player)
+        best_play = montecarlo.get_best_play(board, bot_player, human_player)
+        return [(node.to_json(), mscore) for node, mscore in best_play]
 
     return app

--- a/src/quantikai/wsgi.py
+++ b/src/quantikai/wsgi.py
@@ -6,6 +6,7 @@ from quantikai.bot import montecarlo
 
 PLAYER_WIN_MSG = "Congratulations, you win!"
 BOT_WIN_MSG = "The bot wins!"
+# TODO - not using the file
 MONTECARLO_FILE = pathlib.Path("montecarlo_tree_blue.json")
 
 

--- a/src/quantikai/wsgi.py
+++ b/src/quantikai/wsgi.py
@@ -1,6 +1,5 @@
 from flask import Flask, render_template, request, session, jsonify
 import pathlib
-import time
 
 from quantikai import game, bot
 from quantikai.bot import montecarlo

--- a/src/quantikai/wsgi.py
+++ b/src/quantikai/wsgi.py
@@ -6,6 +6,7 @@ from quantikai.bot import montecarlo
 
 PLAYER_WIN_MSG = "Congratulations, you win!"
 BOT_WIN_MSG = "The bot wins!"
+MONTECARLO_FILE = pathlib.Path("montecarlo_tree_blue.json")
 
 
 def create_app():
@@ -66,7 +67,12 @@ def create_app():
         if not board.have_possible_move(bot_player.color):
             game_is_over = True
             win_message = PLAYER_WIN_MSG
-        move: game.Move = bot.get_best_move(board, bot_player, human_player)
+        move: game.Move = bot.get_best_move(
+            board,
+            bot_player,
+            human_player,
+            game_tree_file=MONTECARLO_FILE if MONTECARLO_FILE.exists() else None,
+        )
         if move is None:
             game_is_over = True
             win_message = PLAYER_WIN_MSG
@@ -97,9 +103,19 @@ def create_app():
         bot_player = game.Player.from_json(session["bot_player"])
         if session["next_player"] == "human_player":
             return montecarlo.get_move_stats(
-                board, human_player, bot_player, depth=depth
+                board,
+                human_player,
+                bot_player,
+                depth=depth,
+                game_tree_file=MONTECARLO_FILE if MONTECARLO_FILE.exists() else None,
             )
-        return montecarlo.get_move_stats(board, bot_player, human_player, depth=depth)
+        return montecarlo.get_move_stats(
+            board,
+            bot_player,
+            human_player,
+            depth=depth,
+            game_tree_file=MONTECARLO_FILE if MONTECARLO_FILE.exists() else None,
+        )
 
     @app.post("/gameprediction")
     def get_best_play():
@@ -108,8 +124,18 @@ def create_app():
         bot_player = game.Player.from_json(session["bot_player"])
         best_play = None
         if session["next_player"] == "human_player":
-            best_play = montecarlo.get_best_play(board, human_player, bot_player)
-        best_play = montecarlo.get_best_play(board, bot_player, human_player)
+            best_play = montecarlo.get_best_play(
+                board,
+                human_player,
+                bot_player,
+                game_tree_file=MONTECARLO_FILE if MONTECARLO_FILE.exists() else None,
+            )
+        best_play = montecarlo.get_best_play(
+            board,
+            bot_player,
+            human_player,
+            game_tree_file=MONTECARLO_FILE if MONTECARLO_FILE.exists() else None,
+        )
         return [(node.to_json(), mscore) for node, mscore in best_play]
 
     return app

--- a/tests/bot/montecarlo/test_game_tree.py
+++ b/tests/bot/montecarlo/test_game_tree.py
@@ -10,14 +10,7 @@ from quantikai.bot.montecarlo.node import Node
 
 @pytest.fixture
 def fixture_board():
-    return Board(
-        board=[
-            [(Pawns.A, Colors.BLUE), None, None, None],
-            [None, None, None, None],
-            [None, None, None, None],
-            [None, None, None, None],
-        ]
-    )
+    return Board(board={(0, 0): (Pawns.A, Colors.BLUE)})
 
 
 @pytest.fixture

--- a/tests/bot/montecarlo/test_game_tree.py
+++ b/tests/bot/montecarlo/test_game_tree.py
@@ -1,7 +1,5 @@
 import pytest
-import copy
 
-from quantikai.bot.montecarlo import game_tree
 from quantikai.bot.montecarlo.main import GameTree, MonteCarloScore
 from quantikai.bot.montecarlo.score import DEFAULT_UCT
 from quantikai.game import Board, Pawns, Colors, Move

--- a/tests/bot/montecarlo/test_game_tree.py
+++ b/tests/bot/montecarlo/test_game_tree.py
@@ -2,7 +2,7 @@ import pytest
 
 from quantikai.bot.montecarlo.main import GameTree, MonteCarloScore
 from quantikai.bot.montecarlo.score import DEFAULT_UCT
-from quantikai.game import Board, Pawns, Colors, Move
+from quantikai.game import Board, Pawns, Colors, Move, FrozenBoard
 from quantikai.bot.montecarlo.node import Node
 
 
@@ -144,11 +144,25 @@ def test_get_best_play_depth_1(board, game_tree, parent_node, node):
 
 def test_to_file(game_tree, tmp_path):
     filepath = tmp_path / "game_tree.json"
-    game_tree.to_file(filepath)
+    game_tree.to_file(filepath, player_color=Colors.BLUE)
 
 
-def test_from_file(game_tree, tmp_path):
+def test_from_file_red(game_tree, tmp_path, board):
     filepath = tmp_path / "game_tree.json"
-    game_tree.to_file(filepath)
+    game_tree.to_file(filepath, player_color=Colors.RED)
+    gm: GameTree = GameTree.from_file(filepath)
+    assert gm._game_tree == {
+        Node(
+            board=board.get_frozen(), move_to_play=Move(2, 2, Pawns.A, Colors.RED)
+        ): MonteCarloScore(times_visited=0, score=0, uct=DEFAULT_UCT),
+        Node(
+            board=board.get_frozen(), move_to_play=Move(2, 3, Pawns.A, Colors.RED)
+        ): MonteCarloScore(times_visited=0, score=0, uct=DEFAULT_UCT),
+    }
+
+
+def test_from_file_blue(game_tree, tmp_path):
+    filepath = tmp_path / "game_tree.json"
+    game_tree.to_file(filepath, player_color=Colors.BLUE)
     gm = GameTree.from_file(filepath)
-    assert gm._game_tree == game_tree._game_tree
+    assert len(gm._game_tree) == 0

--- a/tests/bot/montecarlo/test_game_tree.py
+++ b/tests/bot/montecarlo/test_game_tree.py
@@ -9,169 +9,148 @@ from quantikai.bot.montecarlo.node import Node
 
 
 @pytest.fixture
-def fixture_board():
+def board():
     return Board(board={(0, 0): (Pawns.A, Colors.BLUE)})
 
 
 @pytest.fixture
-def fixture_parent_node(fixture_board):
-    return Node(board=fixture_board.get_frozen(), move_to_play=None)
+def parent_node(board):
+    return Node(board=board.get_frozen(), move_to_play=None)
 
 
 @pytest.fixture
-def fixture_node(fixture_board):
-    return Node(
-        board=fixture_board.get_frozen(), move_to_play=Move(2, 2, Pawns.A, Colors.RED)
-    )
+def node(board):
+    return Node(board=board.get_frozen(), move_to_play=Move(2, 2, Pawns.A, Colors.RED))
 
 
 @pytest.fixture
-def fixture_game_tree(fixture_board, fixture_parent_node, fixture_node):
+def game_tree(board, parent_node, node):
     game_tree = GameTree()
-    game_tree.add(fixture_parent_node)
-    game_tree.add(fixture_node)
+    game_tree.add(parent_node)
+    game_tree.add(node)
     game_tree.add(
         Node(
-            board=fixture_board.get_frozen(),
+            board=board.get_frozen(),
             move_to_play=Move(2, 3, Pawns.A, Colors.RED),
         )
     )
     return game_tree
 
 
-def test_add_no_parent(fixture_board):
-    fixture_node = Node(board=fixture_board.get_frozen(), move_to_play=None)
+def test_add_no_parent(board):
+    node = Node(board=board.get_frozen(), move_to_play=None)
     game_tree = GameTree()
-    game_tree.add(fixture_node)
-    score = game_tree.compute_score(fixture_node, parent_node=None)
+    game_tree.add(node)
+    score = game_tree.compute_score(node, parent_node=None)
     assert score == DEFAULT_UCT
 
 
-def test_add_parent(fixture_game_tree, fixture_parent_node, fixture_node):
+def test_add_parent(game_tree, parent_node, node):
 
-    score = fixture_game_tree.compute_score(
-        fixture_node, parent_node=fixture_parent_node
-    )
+    score = game_tree.compute_score(node, parent_node=parent_node)
     assert score == DEFAULT_UCT
 
 
-def test_add_parent_visit(fixture_game_tree, fixture_parent_node, fixture_node):
+def test_add_parent_visit(game_tree, parent_node, node):
 
-    fixture_game_tree.update(fixture_parent_node, reward=1)
-    fixture_game_tree.update(fixture_node, reward=1)
-    score = fixture_game_tree.compute_score(
-        fixture_node, parent_node=fixture_parent_node
-    )
+    game_tree.update(parent_node, reward=1)
+    game_tree.update(node, reward=1)
+    score = game_tree.compute_score(node, parent_node=parent_node)
     assert score == 1.0
 
 
-def test_best_move(fixture_board, fixture_game_tree, fixture_parent_node, fixture_node):
+def test_best_move(board, game_tree, parent_node, node):
 
-    fixture_game_tree.update(fixture_parent_node, reward=1)
-    fixture_game_tree.update(fixture_node, reward=1)
-    fixture_game_tree.compute_score(fixture_parent_node, parent_node=None)
-    fixture_game_tree.compute_score(fixture_node, parent_node=fixture_parent_node)
+    game_tree.update(parent_node, reward=1)
+    game_tree.update(node, reward=1)
+    game_tree.compute_score(parent_node, parent_node=None)
+    game_tree.compute_score(node, parent_node=parent_node)
 
-    best_move = fixture_game_tree.get_best_move(fixture_board.get_frozen())
-    assert best_move == fixture_node.move_to_play
+    best_move = game_tree.get_best_move(board.get_frozen())
+    assert best_move == node.move_to_play
 
 
-def test_get_best_play_not_visited(
-    fixture_board, fixture_game_tree, fixture_parent_node, fixture_node
-):
-    best_play = fixture_game_tree.get_best_play(fixture_board.get_frozen(), depth=16)
+def test_get_best_play_not_visited(board, game_tree, parent_node, node):
+    best_play = game_tree.get_best_play(board.get_frozen(), depth=16)
     assert len(best_play) == 0
 
 
-def test_get_best_play_max_depth(
-    fixture_board, fixture_game_tree, fixture_parent_node, fixture_node
-):
-    fixture_game_tree.update(fixture_parent_node, reward=1)
-    fixture_game_tree.update(fixture_node, reward=1)
-    fixture_game_tree.compute_score(fixture_parent_node, parent_node=None)
-    fixture_game_tree.compute_score(fixture_node, parent_node=fixture_parent_node)
+def test_get_best_play_max_depth(board, game_tree, parent_node, node):
+    game_tree.update(parent_node, reward=1)
+    game_tree.update(node, reward=1)
+    game_tree.compute_score(parent_node, parent_node=None)
+    game_tree.compute_score(node, parent_node=parent_node)
 
-    best_play = fixture_game_tree.get_best_play(fixture_board.get_frozen(), depth=16)
-    assert best_play == [
-        (fixture_node, MonteCarloScore(times_visited=1, score=1, uct=1.0))
-    ]
+    best_play = game_tree.get_best_play(board.get_frozen(), depth=16)
+    assert best_play == [(node, MonteCarloScore(times_visited=1, score=1, uct=1.0))]
 
 
-def test_get_best_play_depth_0(
-    fixture_board, fixture_game_tree, fixture_parent_node, fixture_node
-):
-    fixture_game_tree.update(fixture_parent_node, reward=1)
-    fixture_game_tree.update(fixture_node, reward=1)
-    fixture_game_tree.compute_score(fixture_parent_node, parent_node=None)
-    fixture_game_tree.compute_score(fixture_node, parent_node=fixture_parent_node)
+def test_get_best_play_depth_0(board, game_tree, parent_node, node):
+    game_tree.update(parent_node, reward=1)
+    game_tree.update(node, reward=1)
+    game_tree.compute_score(parent_node, parent_node=None)
+    game_tree.compute_score(node, parent_node=parent_node)
 
-    best_play = fixture_game_tree.get_best_play(fixture_board.get_frozen(), depth=0)
-    assert best_play == [
-        (fixture_node, MonteCarloScore(times_visited=1, score=1, uct=1.0))
-    ]
+    best_play = game_tree.get_best_play(board.get_frozen(), depth=0)
+    assert best_play == [(node, MonteCarloScore(times_visited=1, score=1, uct=1.0))]
 
 
-def test_get_best_play_depth_less(
-    fixture_board, fixture_game_tree, fixture_parent_node, fixture_node
-):
+def test_get_best_play_depth_less(board, game_tree, parent_node, node):
     # stop at depth 0
-    frozen = fixture_board.get_frozen()
+    frozen = board.get_frozen()
 
-    fixture_board.play(fixture_node.move_to_play)
+    board.play(node.move_to_play)
     extra_node = Node(
-        board=fixture_board.get_frozen(), move_to_play=Move(0, 3, Pawns.C, Colors.BLUE)
+        board=board.get_frozen(), move_to_play=Move(0, 3, Pawns.C, Colors.BLUE)
     )
-    fixture_game_tree.add(extra_node)
+    game_tree.add(extra_node)
 
-    fixture_game_tree.update(fixture_parent_node, reward=1)
-    fixture_game_tree.update(fixture_node, reward=1)
-    fixture_game_tree.update(extra_node, reward=1)
+    game_tree.update(parent_node, reward=1)
+    game_tree.update(node, reward=1)
+    game_tree.update(extra_node, reward=1)
 
-    fixture_game_tree.compute_score(fixture_parent_node, parent_node=None)
-    fixture_game_tree.compute_score(fixture_node, parent_node=fixture_parent_node)
-    fixture_game_tree.compute_score(extra_node, parent_node=fixture_node)
+    game_tree.compute_score(parent_node, parent_node=None)
+    game_tree.compute_score(node, parent_node=parent_node)
+    game_tree.compute_score(extra_node, parent_node=node)
 
-    best_play = fixture_game_tree.get_best_play(frozen, depth=0)
-    assert best_play == [
-        (fixture_node, MonteCarloScore(times_visited=1, score=1, uct=1.0))
-    ]
+    best_play = game_tree.get_best_play(frozen, depth=0)
+    assert best_play == [(node, MonteCarloScore(times_visited=1, score=1, uct=1.0))]
 
 
-def test_get_best_play_depth_1(
-    fixture_board, fixture_game_tree, fixture_parent_node, fixture_node
-):
+def test_get_best_play_depth_1(board, game_tree, parent_node, node):
     # stop at depth 0
-    frozen = fixture_board.get_frozen()
-    fixture_board.play(fixture_node.move_to_play)
+    frozen = board.get_frozen()
+    board.play(node.move_to_play)
     extra_node = Node(
-        board=fixture_board.get_frozen(), move_to_play=Move(0, 3, Pawns.C, Colors.BLUE)
+        board=board.get_frozen(), move_to_play=Move(0, 3, Pawns.C, Colors.BLUE)
     )
-    fixture_game_tree.add(extra_node)
+    game_tree.add(extra_node)
 
-    fixture_game_tree.update(fixture_parent_node, reward=1)
-    fixture_game_tree.update(fixture_node, reward=1)
-    fixture_game_tree.update(extra_node, reward=1)
+    game_tree.update(parent_node, reward=1)
+    game_tree.update(node, reward=1)
+    game_tree.update(extra_node, reward=1)
 
-    fixture_game_tree.compute_score(fixture_parent_node, parent_node=None)
-    fixture_game_tree.compute_score(fixture_node, parent_node=fixture_parent_node)
-    fixture_game_tree.compute_score(extra_node, parent_node=fixture_node)
+    game_tree.compute_score(parent_node, parent_node=None)
+    game_tree.compute_score(node, parent_node=parent_node)
+    game_tree.compute_score(extra_node, parent_node=node)
 
-    best_play = fixture_game_tree.get_best_play(frozen, depth=1)
+    best_play = game_tree.get_best_play(frozen, depth=1)
     assert best_play == [
-        (fixture_node, MonteCarloScore(times_visited=1, score=1, uct=1.0)),
+        (node, MonteCarloScore(times_visited=1, score=1, uct=1.0)),
         (extra_node, MonteCarloScore(times_visited=1, score=1, uct=1.0)),
     ]
 
 
 # TODO test get_move_stats
-# TODO test to_file and from_file
-def test_to_file(fixture_game_tree, tmp_path):
-    filepath = tmp_path / "game_tree.json"
-    fixture_game_tree.to_file(filepath)
 
 
-def test_from_file(fixture_game_tree, tmp_path):
+def test_to_file(game_tree, tmp_path):
     filepath = tmp_path / "game_tree.json"
-    fixture_game_tree.to_file(filepath)
+    game_tree.to_file(filepath)
+
+
+def test_from_file(game_tree, tmp_path):
+    filepath = tmp_path / "game_tree.json"
+    game_tree.to_file(filepath)
     gm = GameTree.from_file(filepath)
-    # TODO check gm content
+    assert gm._game_tree == game_tree._game_tree

--- a/tests/bot/montecarlo/test_game_tree.py
+++ b/tests/bot/montecarlo/test_game_tree.py
@@ -115,13 +115,11 @@ def test_get_best_play_depth_less(
     fixture_board, fixture_game_tree, fixture_parent_node, fixture_node
 ):
     # stop at depth 0
-    board = copy.deepcopy(fixture_board)
-    board.board[fixture_node.move_to_play.x][fixture_node.move_to_play.y] = (
-        fixture_node.move_to_play.pawn,
-        fixture_node.move_to_play.color,
-    )
+    frozen = fixture_board.get_frozen()
+
+    fixture_board.play(fixture_node.move_to_play)
     extra_node = Node(
-        board=board.get_frozen(), move_to_play=Move(0, 3, Pawns.C, Colors.BLUE)
+        board=fixture_board.get_frozen(), move_to_play=Move(0, 3, Pawns.C, Colors.BLUE)
     )
     fixture_game_tree.add(extra_node)
 
@@ -133,7 +131,7 @@ def test_get_best_play_depth_less(
     fixture_game_tree.compute_score(fixture_node, parent_node=fixture_parent_node)
     fixture_game_tree.compute_score(extra_node, parent_node=fixture_node)
 
-    best_play = fixture_game_tree.get_best_play(fixture_board.get_frozen(), depth=0)
+    best_play = fixture_game_tree.get_best_play(frozen, depth=0)
     assert best_play == [
         (fixture_node, MonteCarloScore(times_visited=1, score=1, uct=1.0))
     ]
@@ -143,13 +141,10 @@ def test_get_best_play_depth_1(
     fixture_board, fixture_game_tree, fixture_parent_node, fixture_node
 ):
     # stop at depth 0
-    board = copy.deepcopy(fixture_board)
-    board.board[fixture_node.move_to_play.x][fixture_node.move_to_play.y] = (
-        fixture_node.move_to_play.pawn,
-        fixture_node.move_to_play.color,
-    )
+    frozen = fixture_board.get_frozen()
+    fixture_board.play(fixture_node.move_to_play)
     extra_node = Node(
-        board=board.get_frozen(), move_to_play=Move(0, 3, Pawns.C, Colors.BLUE)
+        board=fixture_board.get_frozen(), move_to_play=Move(0, 3, Pawns.C, Colors.BLUE)
     )
     fixture_game_tree.add(extra_node)
 
@@ -161,7 +156,7 @@ def test_get_best_play_depth_1(
     fixture_game_tree.compute_score(fixture_node, parent_node=fixture_parent_node)
     fixture_game_tree.compute_score(extra_node, parent_node=fixture_node)
 
-    best_play = fixture_game_tree.get_best_play(fixture_board.get_frozen(), depth=1)
+    best_play = fixture_game_tree.get_best_play(frozen, depth=1)
     assert best_play == [
         (fixture_node, MonteCarloScore(times_visited=1, score=1, uct=1.0)),
         (extra_node, MonteCarloScore(times_visited=1, score=1, uct=1.0)),

--- a/tests/bot/montecarlo/test_game_tree.py
+++ b/tests/bot/montecarlo/test_game_tree.py
@@ -165,3 +165,12 @@ def test_get_best_play_depth_1(
 
 # TODO test get_move_stats
 # TODO test to_file and from_file
+def test_to_file(fixture_game_tree, tmp_path):
+    filepath = tmp_path / "game_tree.json"
+    fixture_game_tree.to_file(filepath)
+
+def test_from_file(fixture_game_tree, tmp_path):
+    filepath = tmp_path / "game_tree.json"
+    fixture_game_tree.to_file(filepath)
+    gm = GameTree.from_file(filepath)
+    # TODO check gm content

--- a/tests/bot/montecarlo/test_game_tree.py
+++ b/tests/bot/montecarlo/test_game_tree.py
@@ -169,6 +169,7 @@ def test_to_file(fixture_game_tree, tmp_path):
     filepath = tmp_path / "game_tree.json"
     fixture_game_tree.to_file(filepath)
 
+
 def test_from_file(fixture_game_tree, tmp_path):
     filepath = tmp_path / "game_tree.json"
     fixture_game_tree.to_file(filepath)

--- a/tests/bot/montecarlo/test_montecarlo.py
+++ b/tests/bot/montecarlo/test_montecarlo.py
@@ -11,32 +11,24 @@ from quantikai.bot import montecarlo
 
 def test_best_move_none():
     board = Board(
-        board=[
-            [
-                (Pawns.A, Colors.BLUE),
-                (Pawns.B, Colors.BLUE),
-                (Pawns.C, Colors.BLUE),
-                (Pawns.C, Colors.BLUE),
-            ],
-            [
-                (Pawns.C, Colors.RED),
-                (Pawns.B, Colors.BLUE),
-                (Pawns.B, Colors.BLUE),
-                (Pawns.B, Colors.BLUE),
-            ],
-            [
-                (Pawns.B, Colors.BLUE),
-                (Pawns.D, Colors.RED),
-                (Pawns.B, Colors.BLUE),
-                (Pawns.B, Colors.BLUE),
-            ],
-            [
-                (Pawns.B, Colors.BLUE),
-                (Pawns.B, Colors.BLUE),
-                (Pawns.B, Colors.BLUE),
-                (Pawns.B, Colors.BLUE),
-            ],
-        ]
+        board={
+            (0, 0): (Pawns.A, Colors.BLUE),
+            (0, 1): (Pawns.C, Colors.RED),
+            (0, 2): (Pawns.B, Colors.RED),
+            (0, 3): (Pawns.B, Colors.RED),
+            (1, 0): (Pawns.B, Colors.RED),
+            (1, 1): (Pawns.C, Colors.RED),
+            (1, 2): (Pawns.B, Colors.RED),
+            (1, 3): (Pawns.B, Colors.RED),
+            (2, 0): (Pawns.B, Colors.RED),
+            (2, 1): (Pawns.D, Colors.BLUE),
+            (2, 2): (Pawns.A, Colors.BLUE),
+            (2, 3): (Pawns.B, Colors.BLUE),
+            (3, 0): (Pawns.A, Colors.BLUE),
+            (3, 1): (Pawns.D, Colors.BLUE),
+            (3, 2): (Pawns.A, Colors.BLUE),
+            (3, 3): (Pawns.D, Colors.BLUE),
+        }
     )
     blue_player = Player(
         color=Colors.BLUE,
@@ -63,32 +55,24 @@ def test_best_move_none():
 def test_best_move_last_full_board():
     # Test with only one possibility
     board = Board(
-        board=[
-            [
-                (Pawns.A, Colors.BLUE),
-                (Pawns.B, Colors.BLUE),
-                (Pawns.C, Colors.BLUE),
-                None,
-            ],
-            [
-                (Pawns.C, Colors.RED),
-                (Pawns.C, Colors.RED),
-                (Pawns.B, Colors.RED),
-                (Pawns.D, Colors.BLUE),
-            ],
-            [
-                (Pawns.A, Colors.BLUE),
-                (Pawns.D, Colors.RED),
-                (Pawns.C, Colors.BLUE),
-                None,
-            ],
-            [
-                (Pawns.D, Colors.RED),
-                (Pawns.B, Colors.BLUE),
-                (Pawns.A, Colors.RED),
-                (Pawns.A, Colors.RED),
-            ],
-        ]
+        board={
+            (0, 0): (Pawns.A, Colors.BLUE),
+            (0, 1): (Pawns.B, Colors.BLUE),
+            (0, 2): (Pawns.C, Colors.BLUE),
+            # (0, 3): None
+            (1, 0): (Pawns.C, Colors.RED),
+            (1, 1): (Pawns.C, Colors.RED),
+            (1, 2): (Pawns.B, Colors.RED),
+            (1, 3): (Pawns.D, Colors.BLUE),
+            (2, 0): (Pawns.A, Colors.BLUE),
+            (2, 1): (Pawns.D, Colors.RED),
+            (2, 2): (Pawns.C, Colors.BLUE),
+            # (2, 3): None
+            (3, 0): (Pawns.D, Colors.RED),
+            (3, 1): (Pawns.B, Colors.BLUE),
+            (3, 2): (Pawns.A, Colors.RED),
+            (3, 3): (Pawns.A, Colors.RED),
+        }
     )
     blue_player = Player(
         color=Colors.BLUE,
@@ -118,32 +102,24 @@ def test_montecarlo_algo():
     #     3 |_Dr_||_Bb_| |_Ar_||_Ar_|
     # Test with only one possibility
     board = Board(
-        board=[
-            [
-                (Pawns.A, Colors.BLUE),
-                (Pawns.B, Colors.BLUE),
-                (Pawns.C, Colors.BLUE),
-                None,
-            ],
-            [
-                (Pawns.C, Colors.RED),
-                (Pawns.C, Colors.RED),
-                (Pawns.B, Colors.RED),
-                (Pawns.D, Colors.BLUE),
-            ],
-            [
-                (Pawns.A, Colors.BLUE),
-                (Pawns.D, Colors.RED),
-                (Pawns.C, Colors.BLUE),
-                None,
-            ],
-            [
-                (Pawns.D, Colors.RED),
-                (Pawns.B, Colors.BLUE),
-                (Pawns.A, Colors.RED),
-                (Pawns.A, Colors.RED),
-            ],
-        ]
+        board={
+            (0, 0): (Pawns.A, Colors.BLUE),
+            (0, 1): (Pawns.B, Colors.BLUE),
+            (0, 2): (Pawns.C, Colors.BLUE),
+            # (0, 3): None
+            (1, 0): (Pawns.C, Colors.RED),
+            (1, 1): (Pawns.C, Colors.RED),
+            (1, 2): (Pawns.B, Colors.RED),
+            (1, 3): (Pawns.D, Colors.BLUE),
+            (2, 0): (Pawns.A, Colors.BLUE),
+            (2, 1): (Pawns.D, Colors.RED),
+            (2, 2): (Pawns.C, Colors.BLUE),
+            # (2, 3): None
+            (3, 0): (Pawns.D, Colors.RED),
+            (3, 1): (Pawns.B, Colors.BLUE),
+            (3, 2): (Pawns.A, Colors.RED),
+            (3, 3): (Pawns.A, Colors.RED),
+        }
     )
     blue_player = Player(
         color=Colors.BLUE,
@@ -186,32 +162,24 @@ def test_montecarlo_algo_depth_2():
     #     2 |_Ab_||_Dr_| |_Cb_||____|
     #     3 |_Dr_||_Bb_| |_Ar_||_Ar_|
     board = Board(
-        board=[
-            [
-                (Pawns.A, Colors.BLUE),
-                (Pawns.B, Colors.BLUE),
-                (Pawns.C, Colors.BLUE),
-                None,
-            ],
-            [
-                (Pawns.C, Colors.RED),
-                (Pawns.C, Colors.RED),
-                None,
-                (Pawns.D, Colors.BLUE),
-            ],
-            [
-                (Pawns.A, Colors.BLUE),
-                (Pawns.D, Colors.RED),
-                (Pawns.C, Colors.BLUE),
-                None,
-            ],
-            [
-                (Pawns.D, Colors.RED),
-                (Pawns.B, Colors.BLUE),
-                (Pawns.A, Colors.RED),
-                (Pawns.A, Colors.RED),
-            ],
-        ]
+        board={
+            (0, 0): (Pawns.A, Colors.BLUE),
+            (0, 1): (Pawns.B, Colors.BLUE),
+            (0, 2): (Pawns.C, Colors.BLUE),
+            # (0, 3): None
+            (1, 0): (Pawns.C, Colors.RED),
+            (1, 1): (Pawns.C, Colors.RED),
+            # (1, 2): (None
+            (1, 3): (Pawns.D, Colors.BLUE),
+            (2, 0): (Pawns.A, Colors.BLUE),
+            (2, 1): (Pawns.D, Colors.RED),
+            (2, 2): (Pawns.C, Colors.BLUE),
+            # (2, 3): None
+            (3, 0): (Pawns.D, Colors.RED),
+            (3, 1): (Pawns.B, Colors.BLUE),
+            (3, 2): (Pawns.A, Colors.RED),
+            (3, 3): (Pawns.A, Colors.RED),
+        }
     )
     blue_player = Player(
         color=Colors.BLUE,
@@ -247,16 +215,16 @@ def test_montecarlo_algo_depth_2():
         board=board.get_frozen(),
         move_to_play=Move(x=2, y=3, pawn=Pawns("B"), color=Colors.RED),
     )
-    board1 = copy.deepcopy(board.board)
-    board1[1][2] = (Pawns("B"), Colors.RED)
+    board1 = copy.deepcopy(board)
+    board1.play(red_1.move_to_play)
 
-    board2 = copy.deepcopy(board.board)
-    board2[2][3] = (Pawns("B"), Colors.RED)
+    board2 = copy.deepcopy(board)
+    board2.play(red_2.move_to_play)
 
     # second move: D BLUE (0,3)
     # winning move
     blue_1 = Node(
-        board=Board(board1).get_frozen(),
+        board=board1.get_frozen(),
         move_to_play=Move(x=0, y=3, pawn=Pawns("D"), color=Colors.BLUE),
     )
     assert set(nodes) == {root_node, red_1, red_2, blue_1}
@@ -269,12 +237,11 @@ def test_montecarlo_algo_depth_2():
 
 def test_worst_move():
     board = Board(
-        board=[
-            [(Pawns.A, Colors.BLUE), None, None, None],
-            [None, (Pawns.C, Colors.BLUE), None, None],
-            [None, None, None, None],
-            [(Pawns.B, Colors.RED), None, None, None],
-        ]
+        board={
+            (0, 0): (Pawns.A, Colors.BLUE),
+            (1, 1): (Pawns.C, Colors.BLUE),
+            (3, 0): (Pawns.B, Colors.RED),
+        }
     )
     blue_player = Player(
         color=Colors.BLUE,
@@ -296,24 +263,22 @@ def test_worst_move():
     )
     best_move = montecarlo.get_best_move(board, red_player, blue_player)
     assert best_move is not None
-    assert best_move != (1, 0, Pawns.D)
-    assert best_move != (2, 0, Pawns.C)
-    assert best_move != (2, 0, Pawns.D)
+    assert best_move != Move(1, 0, Pawns.D, Colors.RED)
+    assert best_move != Move(2, 0, Pawns.C, Colors.RED)
+    assert best_move != Move(2, 0, Pawns.D, Colors.RED)
 
 
 def test_best_move_1():
     board = Board(
-        board=[
-            [
-                (Pawns.C, Colors.RED),
-                None,
-                (Pawns.C, Colors.RED),
-                (Pawns.D, Colors.BLUE),
-            ],
-            [None, (Pawns.B, Colors.BLUE), None, (Pawns.A, Colors.BLUE)],
-            [(Pawns.B, Colors.RED), None, (Pawns.A, Colors.BLUE), None],
-            [None, None, None, None],
-        ]
+        board={
+            (0, 0): (Pawns.C, Colors.RED),
+            (0, 2): (Pawns.C, Colors.RED),
+            (0, 3): (Pawns.D, Colors.BLUE),
+            (1, 1): (Pawns.B, Colors.BLUE),
+            (1, 3): (Pawns.A, Colors.BLUE),
+            (2, 0): (Pawns.B, Colors.RED),
+            (2, 2): (Pawns.A, Colors.BLUE),
+        }
     )
     blue_player = Player(
         color=Colors.BLUE,
@@ -347,17 +312,14 @@ def test_best_move_last():
     #     2 |____||__D_| |__B_||____|
     #     3 |____||____| |____||____|
     board = Board(
-        board=[
-            [
-                (Pawns.A, Colors.BLUE),
-                (Pawns.B, Colors.BLUE),
-                (Pawns.C, Colors.BLUE),
-                None,
-            ],
-            [(Pawns.C, Colors.RED), None, None, None],
-            [None, (Pawns.D, Colors.RED), (Pawns.B, Colors.RED), None],
-            [None, None, None, None],
-        ]
+        board={
+            (0, 0): (Pawns.A, Colors.BLUE),
+            (0, 1): (Pawns.B, Colors.BLUE),
+            (0, 2): (Pawns.C, Colors.BLUE),
+            (1, 0): (Pawns.C, Colors.RED),
+            (2, 1): (Pawns.D, Colors.RED),
+            (2, 2): (Pawns.B, Colors.RED),
+        }
     )
     blue_player = Player(
         color=Colors.BLUE,

--- a/tests/bot/montecarlo/test_montecarlo.py
+++ b/tests/bot/montecarlo/test_montecarlo.py
@@ -341,3 +341,9 @@ def test_best_move_last():
     )
     best_move = montecarlo.get_best_move(board, blue_player, red_player)
     assert best_move == Move(0, 3, Pawns.D, Colors.BLUE), best_move
+
+
+# TODO
+# test get_best_move with a game tree file
+# test get_best_play with a game tree file
+# test get_move_stats with a game tree file

--- a/tests/bot/test_minmax.py
+++ b/tests/bot/test_minmax.py
@@ -9,32 +9,24 @@ from quantikai.bot import minmax
 
 def test_best_move_none():
     board = Board(
-        board=[
-            [
-                (Pawns.A, Colors.BLUE),
-                (Pawns.B, Colors.BLUE),
-                (Pawns.C, Colors.BLUE),
-                (Pawns.C, Colors.BLUE),
-            ],
-            [
-                (Pawns.C, Colors.RED),
-                (Pawns.B, Colors.BLUE),
-                (Pawns.B, Colors.BLUE),
-                (Pawns.B, Colors.BLUE),
-            ],
-            [
-                (Pawns.B, Colors.BLUE),
-                (Pawns.D, Colors.RED),
-                (Pawns.B, Colors.BLUE),
-                (Pawns.B, Colors.BLUE),
-            ],
-            [
-                (Pawns.B, Colors.BLUE),
-                (Pawns.B, Colors.BLUE),
-                (Pawns.B, Colors.BLUE),
-                (Pawns.B, Colors.BLUE),
-            ],
-        ]
+        board={
+            (0, 0): (Pawns.A, Colors.BLUE),
+            (0, 1): (Pawns.C, Colors.RED),
+            (0, 2): (Pawns.B, Colors.RED),
+            (0, 3): (Pawns.B, Colors.RED),
+            (1, 0): (Pawns.B, Colors.RED),
+            (1, 1): (Pawns.C, Colors.RED),
+            (1, 2): (Pawns.B, Colors.RED),
+            (1, 3): (Pawns.B, Colors.RED),
+            (2, 0): (Pawns.B, Colors.RED),
+            (2, 1): (Pawns.D, Colors.BLUE),
+            (2, 2): (Pawns.A, Colors.BLUE),
+            (2, 3): (Pawns.B, Colors.BLUE),
+            (3, 0): (Pawns.A, Colors.BLUE),
+            (3, 1): (Pawns.D, Colors.BLUE),
+            (3, 2): (Pawns.A, Colors.BLUE),
+            (3, 3): (Pawns.D, Colors.BLUE),
+        }
     )
     blue_player = Player(
         color=Colors.BLUE,
@@ -60,12 +52,11 @@ def test_best_move_none():
 
 def test_worst_move():
     board = Board(
-        board=[
-            [(Pawns.A, Colors.BLUE), None, None, None],
-            [None, (Pawns.C, Colors.BLUE), None, None],
-            [None, None, None, None],
-            [(Pawns.B, Colors.RED), None, None, None],
-        ]
+        board={
+            (0, 0): (Pawns.A, Colors.BLUE),
+            (1, 1): (Pawns.C, Colors.BLUE),
+            (3, 0): (Pawns.B, Colors.RED),
+        }
     )
     blue_player = Player(
         color=Colors.BLUE,
@@ -94,17 +85,15 @@ def test_worst_move():
 
 def test_best_move_1():
     board = Board(
-        board=[
-            [
-                (Pawns.C, Colors.RED),
-                None,
-                (Pawns.C, Colors.RED),
-                (Pawns.D, Colors.BLUE),
-            ],
-            [None, (Pawns.B, Colors.BLUE), None, (Pawns.A, Colors.BLUE)],
-            [(Pawns.B, Colors.RED), None, (Pawns.A, Colors.BLUE), None],
-            [None, None, None, None],
-        ]
+        board={
+            (0, 0): (Pawns.C, Colors.RED),
+            (0, 2): (Pawns.C, Colors.RED),
+            (0, 3): (Pawns.D, Colors.BLUE),
+            (1, 1): (Pawns.B, Colors.BLUE),
+            (1, 3): (Pawns.A, Colors.BLUE),
+            (2, 0): (Pawns.B, Colors.RED),
+            (2, 2): (Pawns.A, Colors.BLUE),
+        }
     )
     blue_player = Player(
         color=Colors.BLUE,
@@ -138,17 +127,14 @@ def test_best_move_last():
     #     2 |____||__D_| |__B_||____|
     #     3 |____||____| |____||____|
     board = Board(
-        board=[
-            [
-                (Pawns.A, Colors.BLUE),
-                (Pawns.B, Colors.BLUE),
-                (Pawns.C, Colors.BLUE),
-                None,
-            ],
-            [(Pawns.C, Colors.RED), None, None, None],
-            [None, (Pawns.D, Colors.RED), (Pawns.B, Colors.RED), None],
-            [None, None, None, None],
-        ]
+        board={
+            (0, 0): (Pawns.A, Colors.BLUE),
+            (0, 1): (Pawns.B, Colors.BLUE),
+            (0, 2): (Pawns.C, Colors.BLUE),
+            (1, 0): (Pawns.C, Colors.RED),
+            (2, 1): (Pawns.D, Colors.RED),
+            (2, 2): (Pawns.B, Colors.RED),
+        }
     )
     blue_player = Player(
         color=Colors.BLUE,

--- a/tests/game/test_board.py
+++ b/tests/game/test_board.py
@@ -162,7 +162,7 @@ def test_play():
     board.play(Move(0, 0, Pawns.A, Colors.BLUE))
     board.play(Move(3, 3, Pawns.B, Colors.RED))
     board.play(Move(1, 1, Pawns.D, Colors.BLUE))
-    assert board.board == {
+    assert board._board == {
         (0, 0): (Pawns.A, Colors.BLUE),
         (3, 3): (Pawns.B, Colors.RED),
         (1, 1): (Pawns.D, Colors.BLUE),
@@ -371,3 +371,25 @@ def test_get_possible_moves_optimize_one_section_1():
         (3, 2),
         (3, 3),
     }
+
+
+def test_from_json_empty():
+    Board.from_json(
+        body=[
+            [None, None, None, None],
+            [None, None, None, None],
+            [None, None, None, None],
+            [None, None, None, None],
+        ]
+    )
+
+
+def test_from_json():
+    Board.from_json(
+        body=[
+            [(Pawns.A, Colors.BLUE), None, None, None],
+            [None, None, None, None],
+            [None, None, None, None],
+            [None, None, None, None],
+        ]
+    )

--- a/tests/game/test_board.py
+++ b/tests/game/test_board.py
@@ -10,46 +10,52 @@ from quantikai.game import Board, Move, Pawns, Colors, InvalidMoveError
 @pytest.fixture
 def fixture_board():
     return Board(
-        board=[
-            [(Pawns.A, Colors.BLUE), None, None, None],
-            [(Pawns.A, Colors.BLUE), None, None, None],
-            [(Pawns.A, Colors.BLUE), None, None, None],
-            [(Pawns.A, Colors.BLUE), None, None, None],
-        ]
+        board={
+            (0, 0): (Pawns.A, Colors.BLUE),
+            (1, 0): (Pawns.A, Colors.BLUE),
+            (2, 0): (Pawns.A, Colors.BLUE),
+            (3, 0): (Pawns.A, Colors.BLUE),
+        }
     )
 
 
 @pytest.fixture
 def fixture_board_win_first():
     return Board(
-        board=[
-            [
-                (Pawns.A, Colors.BLUE),
-                (Pawns.D, Colors.BLUE),
-                (Pawns.C, Colors.BLUE),
-                None,
-            ],
-            [(Pawns.C, Colors.BLUE), None, None, None],
-            [(Pawns.D, Colors.BLUE), None, None, None],
-            [None, None, None, None],
-        ]
+        board={
+            (0, 0): (Pawns.A, Colors.BLUE),
+            (0, 1): (Pawns.D, Colors.BLUE),
+            (0, 2): (Pawns.C, Colors.BLUE),
+            (1, 0): (Pawns.C, Colors.BLUE),
+            (2, 0): (Pawns.D, Colors.BLUE),
+        }
     )
 
 
 @pytest.fixture
 def fixture_board_win_last():
     return Board(
-        board=[
-            [None, None, None, None],
-            [None, None, None, (Pawns.B, Colors.BLUE)],
-            [None, None, None, (Pawns.C, Colors.BLUE)],
-            [
-                None,
-                (Pawns.C, Colors.BLUE),
-                (Pawns.B, Colors.BLUE),
-                (Pawns.D, Colors.BLUE),
-            ],
-        ]
+        board={
+            (1, 3): (Pawns.B, Colors.BLUE),
+            (2, 3): (Pawns.C, Colors.BLUE),
+            (3, 1): (Pawns.C, Colors.BLUE),
+            (3, 2): (Pawns.B, Colors.BLUE),
+            (3, 3): (Pawns.D, Colors.BLUE),
+        }
+    )
+
+
+@pytest.fixture
+def fixture_board_1():
+    return Board(
+        board={
+            (0, 0): (Pawns.B, Colors.RED),
+            (0, 1): (Pawns.A, Colors.RED),
+            (0, 2): (Pawns.B, Colors.RED),
+            (2, 2): (Pawns.A, Colors.BLUE),
+            (2, 3): (Pawns.B, Colors.BLUE),
+            (3, 3): (Pawns.D, Colors.BLUE),
+        }
     )
 
 
@@ -81,17 +87,9 @@ def test_board_piece_already_there(fixture_board):
 @pytest.mark.parametrize(
     "row_idx, column_idx", [(i, j) for i in range(1, 4) for j in range(0, 4)]
 )
-def test_board_invalid_row(row_idx, column_idx):
-    board = Board(
-        board=[
-            [(Pawns.A, Colors.BLUE), None, None, None],
-            [(Pawns.A, Colors.BLUE), None, None, None],
-            [(Pawns.A, Colors.BLUE), None, None, None],
-            [(Pawns.A, Colors.BLUE), None, None, None],
-        ]
-    )
+def test_board_invalid_row(fixture_board, row_idx, column_idx):
     with pytest.raises(InvalidMoveError):
-        board.play(Move(row_idx, column_idx, Pawns.A, Colors.RED))
+        fixture_board.play(Move(row_idx, column_idx, Pawns.A, Colors.RED))
 
 
 @pytest.mark.parametrize(
@@ -99,17 +97,12 @@ def test_board_invalid_row(row_idx, column_idx):
 )
 def test_board_invalid_column(row_idx, column_idx):
     board = Board(
-        board=[
-            [
-                (Pawns.A, Colors.BLUE),
-                (Pawns.A, Colors.BLUE),
-                (Pawns.A, Colors.BLUE),
-                (Pawns.A, Colors.BLUE),
-            ],
-            [None, None, None, None],
-            [None, None, None, None],
-            [None, None, None, None],
-        ]
+        board={
+            (0, 0): (Pawns.A, Colors.BLUE),
+            (0, 1): (Pawns.A, Colors.BLUE),
+            (0, 2): (Pawns.A, Colors.BLUE),
+            (0, 3): (Pawns.A, Colors.BLUE),
+        }
     )
     with pytest.raises(InvalidMoveError):
         board.play(Move(row_idx, column_idx, Pawns.A, Colors.RED))
@@ -120,12 +113,12 @@ def test_board_invalid_column(row_idx, column_idx):
 )
 def test_board_invalid_section(pawn, row_idx, column_idx):
     board = Board(
-        board=[
-            [(Pawns.A, Colors.BLUE), None, None, None],
-            [None, None, (Pawns.B, Colors.BLUE), None],
-            [None, (Pawns.C, Colors.BLUE), None, None],
-            [None, None, None, (Pawns.D, Colors.BLUE)],
-        ]
+        board={
+            (0, 0): (Pawns.A, Colors.BLUE),
+            (1, 2): (Pawns.B, Colors.BLUE),
+            (2, 1): (Pawns.C, Colors.BLUE),
+            (3, 3): (Pawns.D, Colors.BLUE),
+        }
     )
     with pytest.raises(InvalidMoveError):
         board.play(Move(row_idx, column_idx, Pawns[pawn], Colors.RED))
@@ -155,129 +148,87 @@ def test_board_section_win_last(fixture_board_win_last):
     assert fixture_board_win_last.play(Move(2, 2, Pawns.A, Colors.BLUE))
 
 
-def test_board_section_bottom_right_win():
-    board = Board(
-        board=[
-            [(Pawns.B, Colors.RED), (Pawns.A, Colors.RED), (Pawns.B, Colors.RED), None],
-            [None, None, None, None],
-            [None, None, (Pawns.A, Colors.BLUE), (Pawns.B, Colors.BLUE)],
-            [None, None, None, (Pawns.D, Colors.BLUE)],
-        ]
-    )
-    assert board.play(Move(3, 2, Pawns.C, Colors.BLUE))
+def test_board_section_bottom_right_win(fixture_board_1):
+    assert fixture_board_1.play(Move(3, 2, Pawns.C, Colors.BLUE))
 
 
-def test_move_is_not_win():
-    board = Board(
-        board=[
-            [(Pawns.B, Colors.RED), (Pawns.A, Colors.RED), (Pawns.B, Colors.RED), None],
-            [None, None, None, None],
-            [None, None, (Pawns.A, Colors.BLUE), (Pawns.B, Colors.BLUE)],
-            [None, None, None, (Pawns.D, Colors.BLUE)],
-        ]
-    )
-    assert not board.play(Move(3, 2, Pawns.A, Colors.BLUE))
-    assert not board.play(Move(0, 3, Pawns.C, Colors.RED))
+def test_move_is_not_win(fixture_board_1):
+    assert not fixture_board_1.play(Move(3, 2, Pawns.A, Colors.BLUE))
+    assert not fixture_board_1.play(Move(0, 3, Pawns.C, Colors.RED))
 
 
 def test_play():
     board = Board()
-    board.play(Move(0, 0, Pawns["A"], Colors.BLUE))
-    board.play(Move(3, 3, Pawns["B"], Colors.RED))
-    board.play(Move(1, 1, Pawns["D"], Colors.BLUE))
-    assert board.board == [
-        [(Pawns.A, Colors.BLUE), None, None, None],
-        [None, (Pawns.D, Colors.BLUE), None, None],
-        [None, None, None, None],
-        [None, None, None, (Pawns.B, Colors.RED)],
-    ]
+    board.play(Move(0, 0, Pawns.A, Colors.BLUE))
+    board.play(Move(3, 3, Pawns.B, Colors.RED))
+    board.play(Move(1, 1, Pawns.D, Colors.BLUE))
+    assert board.board == {
+        (0, 0): (Pawns.A, Colors.BLUE),
+        (3, 3): (Pawns.B, Colors.RED),
+        (1, 1): (Pawns.D, Colors.BLUE),
+    }
 
 
-def test_have_possible_move():
-    board = Board(
-        board=[
-            [(Pawns.B, Colors.RED), (Pawns.A, Colors.RED), (Pawns.B, Colors.RED), None],
-            [None, None, None, None],
-            [None, None, (Pawns.A, Colors.BLUE), (Pawns.B, Colors.BLUE)],
-            [None, None, None, (Pawns.D, Colors.BLUE)],
-        ]
-    )
-    assert board.have_possible_move(Colors.RED)
-    assert board.have_possible_move(Colors.RED)
+def test_have_possible_move(fixture_board_1):
+    assert fixture_board_1.have_possible_move(Colors.BLUE)
+    assert fixture_board_1.have_possible_move(Colors.RED)
 
 
 def test_no_possible_move_full_board():
     board = Board(
-        board=[
-            [
-                (Pawns.A, Colors.BLUE),
-                (Pawns.C, Colors.RED),
-                (Pawns.B, Colors.RED),
-                (Pawns.B, Colors.RED),
-            ],
-            [
-                (Pawns.B, Colors.RED),
-                (Pawns.C, Colors.RED),
-                (Pawns.B, Colors.RED),
-                (Pawns.B, Colors.RED),
-            ],
-            [
-                (Pawns.B, Colors.RED),
-                (Pawns.D, Colors.BLUE),
-                (Pawns.A, Colors.BLUE),
-                (Pawns.B, Colors.BLUE),
-            ],
-            [
-                (Pawns.A, Colors.BLUE),
-                (Pawns.D, Colors.BLUE),
-                (Pawns.A, Colors.BLUE),
-                (Pawns.D, Colors.BLUE),
-            ],
-        ]
+        board={
+            (0, 0): (Pawns.A, Colors.BLUE),
+            (0, 1): (Pawns.C, Colors.RED),
+            (0, 2): (Pawns.B, Colors.RED),
+            (0, 3): (Pawns.B, Colors.RED),
+            (1, 0): (Pawns.B, Colors.RED),
+            (1, 1): (Pawns.C, Colors.RED),
+            (1, 2): (Pawns.B, Colors.RED),
+            (1, 3): (Pawns.B, Colors.RED),
+            (2, 0): (Pawns.B, Colors.RED),
+            (2, 1): (Pawns.D, Colors.BLUE),
+            (2, 2): (Pawns.A, Colors.BLUE),
+            (2, 3): (Pawns.B, Colors.BLUE),
+            (3, 0): (Pawns.A, Colors.BLUE),
+            (3, 1): (Pawns.D, Colors.BLUE),
+            (3, 2): (Pawns.A, Colors.BLUE),
+            (3, 3): (Pawns.D, Colors.BLUE),
+        }
     )
     assert not board.have_possible_move(Colors.RED)
 
 
 def test_no_valid_move():
     board = Board(
-        board=[
-            [
-                (Pawns.A, Colors.BLUE),
-                (Pawns.C, Colors.BLUE),
-                (Pawns.B, Colors.RED),
-                (Pawns.B, Colors.RED),
-            ],
-            [
-                (Pawns.B, Colors.RED),
-                None,
-                (Pawns.B, Colors.RED),
-                (Pawns.B, Colors.BLUE),
-            ],
-            [
-                (Pawns.B, Colors.RED),
-                (Pawns.D, Colors.BLUE),
-                (Pawns.A, Colors.BLUE),
-                (Pawns.B, Colors.BLUE),
-            ],
-            [
-                (Pawns.A, Colors.BLUE),
-                (Pawns.D, Colors.BLUE),
-                (Pawns.A, Colors.BLUE),
-                (Pawns.D, Colors.BLUE),
-            ],
-        ]
+        board={
+            (0, 0): (Pawns.A, Colors.BLUE),
+            (0, 1): (Pawns.C, Colors.BLUE),
+            (0, 2): (Pawns.B, Colors.RED),
+            (0, 3): (Pawns.B, Colors.RED),
+            (1, 0): (Pawns.B, Colors.RED),
+            # (1,1) is empty
+            (1, 2): (Pawns.B, Colors.RED),
+            (1, 3): (Pawns.B, Colors.BLUE),
+            (2, 0): (Pawns.B, Colors.RED),
+            (2, 1): (Pawns.D, Colors.BLUE),
+            (2, 2): (Pawns.A, Colors.BLUE),
+            (2, 3): (Pawns.B, Colors.BLUE),
+            (3, 0): (Pawns.A, Colors.BLUE),
+            (3, 1): (Pawns.D, Colors.BLUE),
+            (3, 2): (Pawns.A, Colors.BLUE),
+            (3, 3): (Pawns.D, Colors.BLUE),
+        }
     )
     assert not board.have_possible_move(Colors.RED)
 
 
 def test_get_possible_moves():
     board = Board(
-        board=[
-            [None, (Pawns.A, Colors.RED), None, None],
-            [None, None, None, None],
-            [None, None, (Pawns.A, Colors.BLUE), None],
-            [None, None, None, (Pawns.B, Colors.RED)],
-        ]
+        board={
+            (0, 1): (Pawns.A, Colors.RED),
+            (2, 2): (Pawns.A, Colors.BLUE),
+            (3, 3): (Pawns.B, Colors.RED),
+        }
     )
     moves = board.get_possible_moves([Pawns.A], color=Colors.BLUE)
     assert moves == {
@@ -292,12 +243,11 @@ def test_get_possible_moves():
 
 def test_get_possible_moves_pawns():
     board = Board(
-        board=[
-            [None, (Pawns.A, Colors.RED), None, None],
-            [None, None, None, None],
-            [None, None, (Pawns.A, Colors.BLUE), None],
-            [None, None, None, (Pawns.B, Colors.RED)],
-        ]
+        board={
+            (0, 1): (Pawns.A, Colors.RED),
+            (2, 2): (Pawns.A, Colors.BLUE),
+            (3, 3): (Pawns.B, Colors.RED),
+        }
     )
     moves = board.get_possible_moves([Pawns.A, Pawns.B], color=Colors.BLUE)
     a_moves = {
@@ -322,22 +272,19 @@ def test_get_possible_moves_pawns():
 
 def test_get_possible_move_edge_case():
     board = Board(
-        [
-            [
-                (Pawns.A, Colors.BLUE),
-                (Pawns.B, Colors.BLUE),
-                (Pawns.C, Colors.BLUE),
-                None,
-            ],
-            [(Pawns.C, Colors.RED), (Pawns.C, Colors.RED), None, (Pawns.A, Colors.RED)],
-            [
-                (Pawns.B, Colors.BLUE),
-                (Pawns.D, Colors.RED),
-                (Pawns.A, Colors.BLUE),
-                (Pawns.D, Colors.RED),
-            ],
-            [None, None, (Pawns.C, Colors.BLUE), None],
-        ]
+        board={
+            (0, 0): (Pawns.A, Colors.BLUE),
+            (0, 1): (Pawns.B, Colors.BLUE),
+            (0, 2): (Pawns.C, Colors.BLUE),
+            (1, 0): (Pawns.C, Colors.RED),
+            (1, 1): (Pawns.C, Colors.RED),
+            (1, 3): (Pawns.A, Colors.RED),
+            (2, 0): (Pawns.B, Colors.BLUE),
+            (2, 1): (Pawns.D, Colors.RED),
+            (2, 2): (Pawns.A, Colors.BLUE),
+            (2, 3): (Pawns.D, Colors.RED),
+            (3, 2): (Pawns.C, Colors.BLUE),
+        }
     )
     board.print()
     move = (3, 0, Pawns.D, Colors.BLUE)
@@ -393,14 +340,7 @@ def test_get_possible_moves_optimize_one():
 
 
 def test_get_possible_moves_optimize_one_section_1():
-    board = Board(
-        [
-            [None, (Pawns.A, Colors.RED), None, None],
-            [None, None, None, None],
-            [None, None, None, None],
-            [None, None, None, None],
-        ]
-    )
+    board = Board({(0, 1): (Pawns.A, Colors.RED)})
     moves = board.get_possible_moves(
         pawns=list(Pawns), color=Colors.BLUE, optimize=True
     )


### PR DESCRIPTION
## Internal representation as a dict of moves 

```python
  board = {(0,0): ((Pawns.A, Colors.BLUE))}
```

and try to pre-compute and save the MonteCarlo game tree to a file in a more compact way

### results

The Montecarlo search is 1.3-1.5x faster with the move dict implementation.

Time for the bot to compute the second move (5000 iterations) deployed with Flask: from
23s to 15s.

## Save the game tree file

- 50'000 iterations -> 680Mb when saving the whole tree
- 50'000 iterations -> 25.8Mb when saving only up to depth 4 included

Could save only the best move (ie most visited) for each board, but I would lose the board analysis